### PR TITLE
Read voxel size, offset, and units from metadata for an input array. 

### DIFF
--- a/funlib/persistence/arrays/datasets.py
+++ b/funlib/persistence/arrays/datasets.py
@@ -413,6 +413,7 @@ def prepare_ds(
     compressor: Union[str, dict] = "default",
     delete: bool = False,
     force_exact_write_size: bool = False,
+    multiscales_metadata = False,
     units : str = 'nanometer',
     axes : list = ['z', 'y', 'x']
 ) -> Array:
@@ -554,7 +555,8 @@ def prepare_ds(
             ds.attrs["offset"] = total_roi.begin
             
             #add ome-zarr multiscales in the parent group of a newly created zarr array:
-            add_multiscales(root, ds_name, total_roi, voxel_size, units, axes)
+            if multiscales_metadata:
+                add_multiscales_metadata(root, ds_name, total_roi, voxel_size, units, axes)
             
         else:
             ds.attrs["resolution"] = voxel_size[::-1]
@@ -642,7 +644,7 @@ def get_chunk_size_dim(b, target_chunk_size):
 
     return b // best_k
 
-def add_multiscales(root : zarr.hierarchy.Group,
+def add_multiscales_metadata(root : zarr.hierarchy.Group,
                     ds_name : str,
                     total_roi : Roi,
                     voxel_size : Coordinate,

--- a/funlib/persistence/arrays/datasets.py
+++ b/funlib/persistence/arrays/datasets.py
@@ -347,7 +347,7 @@ def open_ds(filename: str, ds_name: str, mode: str = "r") -> Array:
             order = ds.attrs["order"]
         except KeyError:
             order = ds.order
-        voxel_size, offset, units = _read_voxel_size_offset(ds, order)
+        voxel_size, offset = _read_voxel_size_offset(ds, order)
         shape = Coordinate(ds.shape[-len(voxel_size) :])
         roi = Roi(offset, voxel_size * shape)
 
@@ -360,7 +360,7 @@ def open_ds(filename: str, ds_name: str, mode: str = "r") -> Array:
         logger.debug("opening N5 dataset %s in %s", ds_name, filename)
         ds = zarr.open(filename, mode=mode)[ds_name]
 
-        voxel_size, offset, units = _read_voxel_size_offset(ds, "F")
+        voxel_size, offset = _read_voxel_size_offset(ds, "F")
         shape = Coordinate(ds.shape[-len(voxel_size) :])
         roi = Roi(offset, voxel_size * shape)
 
@@ -373,7 +373,7 @@ def open_ds(filename: str, ds_name: str, mode: str = "r") -> Array:
         logger.debug("opening H5 dataset %s in %s", ds_name, filename)
         ds = h5py.File(filename, mode=mode)[ds_name]
 
-        voxel_size, offset, units = _read_voxel_size_offset(ds, "C")
+        voxel_size, offset = _read_voxel_size_offset(ds, "C")
         shape = Coordinate(ds.shape[-len(voxel_size) :])
         roi = Roi(offset, voxel_size * shape)
 

--- a/funlib/persistence/arrays/datasets.py
+++ b/funlib/persistence/arrays/datasets.py
@@ -164,7 +164,7 @@ def check_for_units(n5_array, order):
     for item in [n5_array, parent_group]:
         
         if "units" in item.attrs:
-            return item.attrs["resolution"]
+            return item.attrs["units"]
         elif "pixelResolution" in item.attrs:
             unit = item.attrs["pixelResolution"]["unit"]
             return [unit for _ in range(len(n5_array.shape))]     
@@ -265,12 +265,14 @@ def _read_voxel_size_offset(ds, order="C"):
     # check zarr store
     else:
         #check for attributes in zarr group multiscale
-        voxel_size, offset, units = check_for_attrs_multiscale(ds, multiscale_group, multiscales)
-        if voxel_size != None and offset != None:
-            return voxel_size, offset, units
+        if multiscales:
+            voxel_size, offset, units = check_for_attrs_multiscale(ds, multiscale_group, multiscales)
+            if voxel_size != None and offset != None:
+                return voxel_size, offset, units
+            else:
+                raise ValueError(f"Although multiscale exists within n5 container, no attributes were found.")     
         else:
-            raise ValueError(f"Although multiscale exists in {multiscale_group.path}, no attributes were found.")     
-    
+            raise ValueError(f"No multiscales attribute was found")     
     return voxel_size, offset, units
 
 

--- a/funlib/persistence/arrays/datasets.py
+++ b/funlib/persistence/arrays/datasets.py
@@ -555,7 +555,7 @@ def prepare_ds(
             ds.attrs["offset"] = total_roi.begin
             
             #add ome-zarr multiscales in the parent group of a newly created zarr array:
-            if multiscales_metadata:
+            if multiscales_metadata == True and 'multiscales' not in root.attrs:
                 add_multiscales_metadata(root, ds_name, total_roi, voxel_size, units, axes)
             
         else:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,4 +1,4 @@
-from funlib.persistence.arrays.datasets import _read_voxel_size_offset, check_for_offset, check_for_voxel_size, access_parent
+from funlib.persistence.arrays.datasets import _read_voxel_size_offset, check_for_offset, check_for_voxel_size, access_parent, check_for_attrs_multiscale, check_for_multiscale
 
 import pytest
 from numcodecs import Zstd
@@ -6,16 +6,6 @@ import zarr
 import numpy as np
 
 @pytest.fixture(scope='session')
-def filepaths(tmp_path_factory):
-    path = tmp_path_factory.mktemp('test_data', numbered=False)
-    test_n5_path = path / 'input/test_file.n5'
-    test_zarr_path = path / 'output/test_file.zarr'
-
-    n5_data = populate_n5file(test_n5_path, test_metadata_n5())
-    zarr_data = populate_zarrfile(test_zarr_path, test_metadata_zarr())
-    
-    return (n5_data, zarr_data)
-
 def test_metadata_n5():
     metadata_n5 = {"pixelResolution":{"dimensions":[5.3,4.3,3.3],
                         "unit":"nm"},
@@ -32,6 +22,7 @@ def test_metadata_n5():
                         }
     return metadata_n5
 
+@pytest.fixture(scope='session')
 def test_metadata_zarr():
     zarr_metadata = {
         "multiscales": [
@@ -76,57 +67,85 @@ def test_metadata_zarr():
     }
     return zarr_metadata
     
-    
+@pytest.fixture(scope='session')
+def test_arrays(tmp_path_factory, test_metadata_n5, test_metadata_zarr):
+    path = tmp_path_factory.mktemp('test_data', numbered=False)
+    test_n5_path = path / 'input/test_file.n5'
+    test_zarr_path = path / 'output/test_file.zarr'
 
-#n5 test file
+    n5_arr = populate_n5file(test_n5_path, test_metadata_n5)
+    zarr_arr = populate_zarrfile(test_zarr_path, test_metadata_n5, test_metadata_zarr)
+    
+    return n5_arr, zarr_arr  
+
+#populate array and attrs for  n5 test file
 def populate_n5file(filepath, test_metadata_n5):
     
     store = zarr.N5Store(filepath)
     root = zarr.group(store = store, path = 'test_group', overwrite = True) 
     
     n5_data = zarr.create(store=store, 
-                            path= 'test_data', 
+                            path= 'test_group/test_data', 
                             shape = (100,100, 100),
                             chunks=10,
                             dtype='uint8', compressor=Zstd(level=6))
     n5_data[:] = np.random.rand(100,100, 100)
         
-    n5_data.attrs.update(test_metadata_n5())
-    root.attrs.update(test_metadata_n5())
-  
+    n5_data.attrs.put(test_metadata_n5)
+    root.attrs.put(test_metadata_n5)
     return n5_data
         
     
-#zarr test file
-def populate_zarrfile(filepaths, test_metadata_n5, test_metadata_zarr):
-    zarr_path = filepaths[1]
-    store = zarr.DirectoryStore(zarr_path)
+#populate array and attrs for  zarr test file
+def populate_zarrfile(filepath, test_metadata_n5, test_metadata_zarr):
+    store = zarr.DirectoryStore(filepath)
     root = zarr.group(store = store, path = 'test_group', overwrite = True) 
     
     zarr_data = zarr.create(store=store, 
-                            path= 'test_data', 
+                            path= 'test_group/test_data', 
                             shape = (100,100, 100),
                             chunks=10,
                             dtype='uint8', compressor=Zstd(level=6))
     zarr_data[:] = np.random.rand(100,100, 100)
      
-    zarr_data.attrs.update(test_metadata_n5()) 
-    root.attrs.update(test_metadata_zarr())
-   
+    zarr_data.attrs.update(test_metadata_n5) 
+    root.attrs.update(test_metadata_zarr)
+    
     return zarr_data
         
 
-def test_read_voxel_size_offset(filepaths):
-    #assert voxel_size
-    #assert offset 
-    n5_arr = filepaths[0]
-    zarr_arr = filepaths[1]
+def test_read_voxel_size_offset(test_arrays):
+    
+    n5_arr = test_arrays[0]
+    zarr_arr = test_arrays[1]
     assert _read_voxel_size_offset(n5_arr) == ([5.3, 4.3, 3.3],
-                                               [4.3, 3.3, 2.3],
-                                               ["nanometer","nanometer","nanometer"])
+                                            [4.3, 3.3, 2.3],
+                                            ["nm", "nm", "nm"])
+    
     assert _read_voxel_size_offset(zarr_arr) == ([3.3,4.3,5.3],
-                                                 [2.3, 3.3, 4.3],
-                                                 ["nm", "nm", "nm"])
+                                                [2.3, 3.3, 4.3],
+                                                ["nanometer","nanometer","nanometer"])
+    
+
+@pytest.fixture(scope='session')
+def for_ms(test_arrays):
+    
+    z_arr = test_arrays[1]
+    multiscales, multiscale_group = check_for_multiscale(group = access_parent(z_arr))
+    return z_arr, multiscale_group, multiscales
+
+def test_check_for_attrs_multiscale(for_ms):
+    z_attrs = check_for_attrs_multiscale(for_ms[0], for_ms[1], for_ms[2])
+    assert z_attrs ==  ([3.3,4.3,5.3],
+                        [2.3, 3.3, 4.3],
+                        ["nanometer","nanometer","nanometer"])
+
+    
+
+     
+    
+    
+                                                 
 
 
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,132 @@
+from funlib.persistence.arrays.datasets import _read_voxel_size_offset, check_for_offset, check_for_voxel_size, access_parent
+
+import pytest
+from numcodecs import Zstd
+import zarr
+import numpy as np
+
+@pytest.fixture(scope='session')
+def filepaths(tmp_path_factory):
+    path = tmp_path_factory.mktemp('test_data', numbered=False)
+    test_n5_path = path / 'input/test_file.n5'
+    test_zarr_path = path / 'output/test_file.zarr'
+
+    n5_data = populate_n5file(test_n5_path, test_metadata_n5())
+    zarr_data = populate_zarrfile(test_zarr_path, test_metadata_zarr())
+    
+    return (n5_data, zarr_data)
+
+def test_metadata_n5():
+    metadata_n5 = {"pixelResolution":{"dimensions":[5.3,4.3,3.3],
+                        "unit":"nm"},
+                        "ordering":"C",
+                        "scales":[[1,1,1],[2,2,2]],
+                        "axes":["x","y","z"],
+                        "units":["nm","nm","nm"],
+                        "transform" : {
+                                        "axes": ["z","y","x"],
+                                        "ordering": "C",
+                                        "scale": [5.3, 4.3, 3.3],
+                                        "translate": [4.3, 3.3, 2.3],
+                                        "units": ["nm", "nm", "nm"]}
+                        }
+    return metadata_n5
+
+def test_metadata_zarr():
+    zarr_metadata = {
+        "multiscales": [
+            {
+                "axes": [
+                    {
+                        "name": "z",
+                        "type": "space",
+                        "unit": "nanometer"
+                    },
+                    {
+                        "name": "y",
+                        "type": "space",
+                        "unit": "nanometer"
+                    },
+                    {
+                        "name": "x",
+                        "type": "space",
+                        "unit": "nanometer"
+                    }
+                ],
+                "coordinateTransformations": [],
+                "datasets": [
+                    {
+                        "coordinateTransformations": [
+                            {
+                                "scale": [3.3,4.3,5.3],
+                                "type": "scale"
+                            },
+                            {
+                                "translation": [2.3, 3.3, 4.3],
+                                "type": "translation"
+                            }
+                        ],
+                        "path": "test_data"
+                    }
+                ],
+                "name": "",
+                "version": "0.4"
+            }
+        ]
+    }
+    return zarr_metadata
+    
+    
+
+#n5 test file
+def populate_n5file(filepath, test_metadata_n5):
+    
+    store = zarr.N5Store(filepath)
+    root = zarr.group(store = store, path = 'test_group', overwrite = True) 
+    
+    n5_data = zarr.create(store=store, 
+                            path= 'test_data', 
+                            shape = (100,100, 100),
+                            chunks=10,
+                            dtype='uint8', compressor=Zstd(level=6))
+    n5_data[:] = np.random.rand(100,100, 100)
+        
+    n5_data.attrs.update(test_metadata_n5())
+    root.attrs.update(test_metadata_n5())
+  
+    return n5_data
+        
+    
+#zarr test file
+def populate_zarrfile(filepaths, test_metadata_n5, test_metadata_zarr):
+    zarr_path = filepaths[1]
+    store = zarr.DirectoryStore(zarr_path)
+    root = zarr.group(store = store, path = 'test_group', overwrite = True) 
+    
+    zarr_data = zarr.create(store=store, 
+                            path= 'test_data', 
+                            shape = (100,100, 100),
+                            chunks=10,
+                            dtype='uint8', compressor=Zstd(level=6))
+    zarr_data[:] = np.random.rand(100,100, 100)
+     
+    zarr_data.attrs.update(test_metadata_n5()) 
+    root.attrs.update(test_metadata_zarr())
+   
+    return zarr_data
+        
+
+def test_read_voxel_size_offset(filepaths):
+    #assert voxel_size
+    #assert offset 
+    n5_arr = filepaths[0]
+    zarr_arr = filepaths[1]
+    assert _read_voxel_size_offset(n5_arr) == ([5.3, 4.3, 3.3],
+                                               [4.3, 3.3, 2.3],
+                                               ["nanometer","nanometer","nanometer"])
+    assert _read_voxel_size_offset(zarr_arr) == ([3.3,4.3,5.3],
+                                                 [2.3, 3.3, 4.3],
+                                                 ["nm", "nm", "nm"])
+
+
+


### PR DESCRIPTION
Modified _read_voxel_size_offset function. 

Voxel size and offset could be read from both .n5 and .zarr multiscales attribute of the metadata(attributes.json, .zattrs). Multiscale attribute does not have to be in the immediate parent group of an input array, thus _check_for_multiscale_ function checks every parent group up in the group tree for multiscale until it finds it. 

 If multiscale attribute is not in metadata, for the .n5 store, the voxel size and offset are being searched in other  attributes - "transform", "pixelResolution", "offset", "scale", "resolution". 

In addition, to properly quantify the size of the voxel, along with voxel size and offset, the physical units are also being looked for in "multiscales", "units", and "axes" of the metadata. 